### PR TITLE
[이율] Design: 섹션 보더 사이 간격 수정, 공통 CSS 다시적용, addFavoriteSection아래 여백 적용

### DIFF
--- a/src/pages/List.jsx
+++ b/src/pages/List.jsx
@@ -5,7 +5,7 @@ import Layout from "components/Layout/Layout";
 import Button from "components/Button";
 import Card from "components/Card";
 import ChartSection from "pages/ListPage/ChartSection";
-import creditIcon from "assets/icons/credit.svg";
+import CreditIcon from "assets/icons/credit.svg";
 import styles from "./List.module.scss";
 
 export default function List() {

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -32,44 +32,46 @@ function AddFavoriteSection({ idols }) {
         </h2>
         <div className={styles.sectionContent}>
           <div className={styles.AddFavorite}>
-            <div className={styles.sliderBtn}>
-              <Button.Arrow direction="left" size="lg" />
+            <div className={styles.sliderWrap}>
+              <div className={styles.sliderBtn}>
+                <Button.Arrow direction="left" size="lg" />
+              </div>
+              <div className={styles.slider}>
+                <ul className={styles.gridContainer}>
+                  {idols.map((idol) => {
+                    return (
+                      <li key={idol.id} className={styles.gridItem}>
+                        <input
+                          type="checkbox"
+                          id={idol.id}
+                          className={styles.chkItem}
+                        />
+                        <label htmlFor={idol.id} className={styles.labelItem}>
+                          <div className={styles.imgWrap}>
+                            <RoundImage />
+                          </div>
+                        </label>
+                        <span className={styles.itemInfo}>
+                          <strong className={styles.itemTitle}>
+                            {idol.name}
+                          </strong>
+                          <p className={styles.itemCategory}>{idol.group}</p>
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+              <div className={styles.sliderBtn}>
+                <Button.Arrow direction="right" size="lg" />
+              </div>
             </div>
-            <div className={styles.slider}>
-              <ul className={styles.gridContainer}>
-                {idols.map((idol) => {
-                  return (
-                    <li key={idol.id} className={styles.gridItem}>
-                      <input
-                        type="checkbox"
-                        id={idol.id}
-                        className={styles.chkItem}
-                      />
-                      <label htmlFor={idol.id} className={styles.labelItem}>
-                        <div className={styles.imgWrap}>
-                          <RoundImage />
-                        </div>
-                      </label>
-                      <span className={styles.itemInfo}>
-                        <strong className={styles.itemTitle}>
-                          {idol.name}
-                        </strong>
-                        <p className={styles.itemCategory}>{idol.group}</p>
-                      </span>
-                    </li>
-                  );
-                })}
-              </ul>
+            <div className={styles.btnAddFavorite}>
+              <Button.Round>
+                <img src={icoPlus} alt="icon" aria-hidden="true" />
+                <span>추가하기</span>
+              </Button.Round>
             </div>
-            <div className={styles.sliderBtn}>
-              <Button.Arrow direction="right" size="lg" />
-            </div>
-          </div>
-          <div className={styles.btnAddFavorite}>
-            <Button.Round>
-              <img src={icoPlus} alt="icon" aria-hidden="true" />
-              <span>추가하기</span>
-            </Button.Round>
           </div>
         </div>
       </section>

--- a/src/pages/MyPage.module.scss
+++ b/src/pages/MyPage.module.scss
@@ -104,16 +104,19 @@
 
 /* AddFavoriteSection */
 .AddFavorite {
-  display: flex;
-  align-items: center;
-  position: relative;
-  @media screen and (min-width: $tablet) {
-    gap: 27px;
-    padding-top: 33px;
-  }
-  @media screen and (min-width: $desktop) {
-    gap: 32px;
-    padding-top: 8px;
+  margin-bottom: 80px;
+  .sliderWrap {
+    display: flex;
+    align-items: center;
+    position: relative;
+    @media screen and (min-width: $tablet) {
+      gap: 27px;
+      padding-top: 33px;
+    }
+    @media screen and (min-width: $desktop) {
+      gap: 32px;
+      padding-top: 8px;
+    }
   }
   .sliderBtn {
     display: none;

--- a/src/pages/MyPage.module.scss
+++ b/src/pages/MyPage.module.scss
@@ -2,9 +2,14 @@
 
 /* mypage 공통 */
 .section {
+  padding-top: 32px;
   margin: 0 24px;
   border-top: 1px solid rgba(255, 255, 255, 0.1);
+  @media screen and (min-width: $desktop) {
+    padding-top: 40px;
+  }
   &:first-child {
+    padding-top: 0;
     border-top: none;
     @media screen and (min-width: $desktop) {
       margin-top: 76px;
@@ -12,7 +17,6 @@
   }
   @media screen and (min-width: $tablet) {
     margin: 0 24px;
-    padding: 0;
   }
   @media screen and (min-width: $desktop) {
     margin: 0 auto;
@@ -73,7 +77,7 @@
             width: 100px;
             height: 100px;
           }
-          }
+        }
         // AddFavoriteSection 과 스타일 중복 (itemInfo, itemTitle, itemCategory)
         .itemInfo {
           display: flex;
@@ -97,7 +101,6 @@
     }
   }
 }
-
 
 /* AddFavoriteSection */
 .AddFavorite {


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
myPage section 사이의 보더 디자인 시안과 맞지않았습니다.
![image](https://github.com/miraclee1226/Fandom-k/assets/21290609/5c51ffeb-509a-45f1-9ac7-b27613ecf6a2)


# 어떻게 해결했나요?
- 공통CSS 에 있었던 padding 다시 적용
- addFavoriteSection 구조 수정, 아래 여백 적용

![Screenshot 2024-05-06 at 14 08 58](https://github.com/miraclee1226/Fandom-k/assets/21290609/865d1569-dc03-4551-b8b0-c0d4482aa2a7)
