### PR TITLE
[이율] Feat: support section api연결

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+REACT_APP_BASE_URL="https://fandom-k-api.vercel.app/6-4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint-config-naver": "^2.1.0",
         "eslint-config-prettier": "^9.1.0",
         "prettier": "3.2.5",
+        "react-responsive": "^10.0.0",
         "sass": "^1.75.0",
         "stylelint": "^13.8.0",
         "stylelint-config-prettier": "^8.0.2",
@@ -6692,6 +6693,12 @@
         }
       }
     },
+    "node_modules/css-mediaquery": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==",
+      "dev": true
+    },
     "node_modules/css-minimizer-webpack-plugin": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-3.4.1.tgz",
@@ -10245,6 +10252,12 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==",
+      "dev": true
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -13665,6 +13678,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/matchmediaquery": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.4.2.tgz",
+      "integrity": "sha512-wrZpoT50ehYOudhDjt/YvUJc6eUzcdFPdmbizfgvswCKNHD1/OBOHYJpHie+HXpu6bSkEGieFMYk6VuutaiRfA==",
+      "dev": true,
+      "dependencies": {
+        "css-mediaquery": "^0.1.2"
+      }
+    },
     "node_modules/mathml-tag-names": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
@@ -16810,6 +16832,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-responsive": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-10.0.0.tgz",
+      "integrity": "sha512-N6/UiRLGQyGUqrarhBZmrSmHi2FXSD++N5VbSKsBBvWfG0ZV7asvUBluSv5lSzdMyEVjzZ6Y8DL4OHABiztDOg==",
+      "dev": true,
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.0",
+        "matchmediaquery": "^0.4.2",
+        "prop-types": "^15.6.1",
+        "shallow-equal": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/react-router": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.0.tgz",
@@ -17908,6 +17948,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/shallow-equal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
+      "integrity": "sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg==",
+      "dev": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+        "axios": "^1.6.8",
         "classname": "^0.0.0",
         "eslint-config-naver": "^2.1.0",
         "eslint-config-prettier": "^9.1.0",
@@ -5505,6 +5506,31 @@
       "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -16392,6 +16418,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "axios": "^1.6.8",
     "classname": "^0.0.0",
     "eslint-config-naver": "^2.1.0",
     "eslint-config-prettier": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-config-naver": "^2.1.0",
     "eslint-config-prettier": "^9.1.0",
     "prettier": "3.2.5",
+    "react-responsive": "^10.0.0",
     "sass": "^1.75.0",
     "stylelint": "^13.8.0",
     "stylelint-config-prettier": "^8.0.2",

--- a/src/components/Card/SupportCard/SupportCard.jsx
+++ b/src/components/Card/SupportCard/SupportCard.jsx
@@ -8,8 +8,8 @@ export default function SupportCard({ donation }) {
     <div className={styles.supportCard}>
       <div className={styles.content}>
         <img
-          src="https://search.pstatic.net/common/?src=http%3A%2F%2Fblogfiles.naver.net%2FMjAyMzAxMThfMjAz%2FMDAxNjczOTcwNzQ3NDg2._l8C4TNMoXLMhftgGxhdy1rFRmHPug997-_GIsMKZOcg.VDaJ72QJarXLOAzrR6CwEc8iuT365WmOj2s1ny6SJ0gg.JPEG.nevergetold%2FFmoSb0bWIAIE7S5.jpg&type=sc960_832"
-          alt="뉴진스 민지 이미지"
+          src={donation.idol.profilePicture}
+          alt={`${donation.idol.gorup} ${donation.idol.name} 이미지`}
         />
         <DefaultButton>후원하기</DefaultButton>
       </div>

--- a/src/components/Card/SupportCard/SupportCard.jsx
+++ b/src/components/Card/SupportCard/SupportCard.jsx
@@ -21,15 +21,14 @@ export default function SupportCard({ donation }) {
         <div className={styles.creditInfo}>
           <strong className={styles.credit}>
             <img src={creditImg} alt="필요 크레딧" width="12" />
-            <span>6,000</span>
+            <span>{donation.targetDonation.toLocaleString()}</span>
           </strong>
           <p className={styles.date}>{timeCounter(donation.deadline)}일 남음</p>
         </div>
         <div>
           <LineGraph
-            width="282"
             targetDonation={donation.targetDonation}
-            credit={5000}
+            credit={donation.receivedDonations}
           />
         </div>
       </div>
@@ -37,20 +36,15 @@ export default function SupportCard({ donation }) {
   );
 }
 
-function LineGraph({ width, targetDonation, credit }) {
-  const graphLength = (credit / targetDonation) * width;
+function LineGraph({ targetDonation, credit }) {
+  const graphLength = (credit * 100) / targetDonation;
 
   return (
-    <svg
-      width={width}
-      height="1"
-      viewBox={`0 0 ${width} 1`}
-      className={styles.lineGraph}
-    >
+    <svg width="100%" height="1" className={styles.lineGraph}>
       <line
         x1="0"
         y1="1"
-        x2={width}
+        x2="100%"
         y2="1"
         fill="none"
         strokeWidth="1"
@@ -60,12 +54,12 @@ function LineGraph({ width, targetDonation, credit }) {
       <line
         x1="0"
         y1="1"
-        x2={graphLength}
+        x2={`${graphLength}%`}
         y2="1"
         fill="none"
         strokeWidth="1"
         stroke="#FC4D04"
-        strokeDasharray={width}
+        strokeDasharray="100%"
         strokeDashoffset="dashOffsetLine"
         strokeLinecap="round"
       />

--- a/src/hooks/useRequest.js
+++ b/src/hooks/useRequest.js
@@ -21,9 +21,11 @@ export default function useRequest({ options, skip = false, deps = [] }) {
     try {
       const response = await dispatcher({ ...options, ...args });
 
-      setData(response);
+      setData(() => response);
+      return response;
     } catch (err) {
-      setError(err);
+      setError(() => err);
+      return err;
     } finally {
       setIsLoading(false);
     }
@@ -36,4 +38,3 @@ export default function useRequest({ options, skip = false, deps = [] }) {
 
   return { data, isLoading, error, requestFunc };
 }
-

--- a/src/hooks/useResponsive.js
+++ b/src/hooks/useResponsive.js
@@ -1,0 +1,15 @@
+import { useMediaQuery } from "react-responsive";
+
+export default function useResponsive() {
+  const isPC = useMediaQuery({
+    query: "(min-width:1200px)",
+  });
+  const isTablet = useMediaQuery({
+    query: "(min-width:768px) and (max-width:1119px)",
+  });
+  const isMobile = useMediaQuery({
+    query: "(max-width:767px)",
+  });
+
+  return [isPC, isTablet, isMobile];
+}

--- a/src/hooks/useResponsive.js
+++ b/src/hooks/useResponsive.js
@@ -5,10 +5,10 @@ export default function useResponsive() {
     query: "(min-width:1200px)",
   });
   const isTablet = useMediaQuery({
-    query: "(min-width:768px) and (max-width:1119px)",
+    query: "(min-width:745px) and (max-width:1119px)",
   });
   const isMobile = useMediaQuery({
-    query: "(max-width:767px)",
+    query: "(max-width:744px)",
   });
 
   return [isPC, isTablet, isMobile];

--- a/src/index.js
+++ b/src/index.js
@@ -7,10 +7,6 @@ import "./styles/reset.scss";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+root.render(<App />);
 
 ReactModal.setAppElement("#root");

--- a/src/pages/List/List.module.scss
+++ b/src/pages/List/List.module.scss
@@ -27,7 +27,6 @@
 .slideContainer {
   position: relative;
   margin: 0 auto;
-
   cursor: default;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -66,7 +65,7 @@
 
   .sliderBtn {
     display: none;
-    @media screen and (min-width: $tablet) {
+    @media screen and (min-width: calc($desktop + 78px * 2 + 80px)) {
       display: block;
       position: absolute;
       top: 50%;

--- a/src/pages/List/List.module.scss
+++ b/src/pages/List/List.module.scss
@@ -46,6 +46,8 @@
       gap: 16px;
     }
     @media screen and (min-width: $desktop) {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
       gap: 24px;
     }
     .supportList {
@@ -64,7 +66,7 @@
 
   .sliderBtn {
     display: none;
-    @media screen and (min-width: calc($desktop + 78px * 2 + 80px)) {
+    @media screen and (min-width: $tablet) {
       display: block;
       position: absolute;
       top: 50%;

--- a/src/pages/List/SupportSection.jsx
+++ b/src/pages/List/SupportSection.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import useResponsive from "hooks/useResponsive";
 import axios from "axios";
 import Card from "components/Card";
 import Button from "components/Button";
@@ -10,6 +11,7 @@ export default function SupportSection() {
   const [page, setPage] = useState(0);
   const [prevBtnDisabled, setPrevBtnDisabled] = useState(false);
   const [nextBtnDisabled, setNextBtnDisabled] = useState(false);
+  const [isPC, isTablet, isMobile] = useResponsive();
   const [isDown, setIsDown] = useState(false);
   const [startX, setStartX] = useState(null);
   const [scrollLeft, setScrollLeft] = useState(null);
@@ -42,7 +44,7 @@ export default function SupportSection() {
     });
 
     const response = await instance.get(
-      `/donations?pageSize=4&cursor=${nextCursor}`,
+      `/donations?${isPC ? "pageSize=4" : ""}&cursor=${nextCursor}`,
     );
 
     setDonations(response.data.list);
@@ -83,7 +85,7 @@ export default function SupportSection() {
 
   useEffect(() => {
     handleLoad(cursorArr[page]);
-  }, [page, prevBtnDisabled, nextBtnDisabled]);
+  }, [page, isPC]);
 
   return (
     <>

--- a/src/pages/List/SupportSection.jsx
+++ b/src/pages/List/SupportSection.jsx
@@ -7,10 +7,9 @@ import styles from "./List.module.scss";
 
 export default function SupportSection() {
   const [donations, setDonations] = useState([]);
+  const [nextCursor, setNextCursor] = useState(0);
   const [cursorArr, setCursorArr] = useState([0]);
   const [page, setPage] = useState(0);
-  const [prevBtnDisabled, setPrevBtnDisabled] = useState(false);
-  const [nextBtnDisabled, setNextBtnDisabled] = useState(false);
   const [isPC, isTablet, isMobile] = useResponsive();
   const [isDown, setIsDown] = useState(false);
   const [startX, setStartX] = useState(null);
@@ -37,36 +36,31 @@ export default function SupportSection() {
     slider.current.scrollLeft = scrollLeft - walk;
   };
 
-  const handleLoad = async (nextCursor = 0) => {
+  const handleLoad = async (cursor) => {
     const instance = axios.create({
       baseURL: "https://fandom-k-api.vercel.app/6-4",
       timeout: 10000,
     });
 
     const response = await instance.get(
-      `/donations?${isPC ? "pageSize=4" : ""}&cursor=${nextCursor}`,
+      `/donations?${isPC ? "pageSize=4" : ""}&cursor=${cursor}`,
     );
 
+    if (isPC) {
+      setNextCursor(response.data.nextCursor);
+      setPagination(response.data.nextCursor);
+    } else {
+      setNextCursor(0);
+      setPage(0);
+    }
     setDonations(response.data.list);
-    if (
-      !cursorArr.includes(response.data.nextCursor) &&
-      response.data.nextCursor !== null
-    ) {
-      setCursorArr((prevArr) => [...prevArr, response.data.nextCursor]);
-    }
-
-    if (page === 0) {
-      setPrevBtnDisabled(true);
-    } else {
-      setPrevBtnDisabled(false);
-    }
-    if (response.data.nextCursor === null) {
-      setNextBtnDisabled(true);
-    } else {
-      setNextBtnDisabled(false);
-    }
   };
 
+  const setPagination = (cursor) => {
+    if (!cursorArr.includes(cursor) && cursor !== null) {
+      setCursorArr((prevArr) => [...prevArr, cursor]);
+    }
+  };
   const handlePrevBtn = () => {
     if (donations.length < 4 && page === 0) {
       setPage((prevValue) => prevValue);
@@ -97,7 +91,7 @@ export default function SupportSection() {
               <Button.Arrow
                 direction="left"
                 onClick={handlePrevBtn}
-                disabled={prevBtnDisabled}
+                disabled={page === 0}
               />
             </div>
             <ul
@@ -120,7 +114,7 @@ export default function SupportSection() {
               <Button.Arrow
                 direction="right"
                 onClick={handleNextBtn}
-                disabled={nextBtnDisabled}
+                disabled={nextCursor === null}
               />
             </div>
           </div>

--- a/src/pages/List/SupportSection.jsx
+++ b/src/pages/List/SupportSection.jsx
@@ -6,7 +6,10 @@ import styles from "./List.module.scss";
 
 export default function SupportSection() {
   const [donations, setDonations] = useState([]);
-  const [cursor, setCursor] = useState(0);
+  const [cursorArr, setCursorArr] = useState([0]);
+  const [page, setPage] = useState(0);
+  const [prevBtnDisabled, setPrevBtnDisabled] = useState(false);
+  const [nextBtnDisabled, setNextBtnDisabled] = useState(false);
   const [isDown, setIsDown] = useState(false);
   const [startX, setStartX] = useState(null);
   const [scrollLeft, setScrollLeft] = useState(null);
@@ -32,7 +35,7 @@ export default function SupportSection() {
     slider.current.scrollLeft = scrollLeft - walk;
   };
 
-  const handleLoad = async (nextCursor) => {
+  const handleLoad = async (nextCursor = 0) => {
     const instance = axios.create({
       baseURL: "https://fandom-k-api.vercel.app/6-4",
       timeout: 10000,
@@ -43,18 +46,44 @@ export default function SupportSection() {
     );
 
     setDonations(response.data.list);
-    setCursor(response.data.nextCursor);
+    if (
+      !cursorArr.includes(response.data.nextCursor) &&
+      response.data.nextCursor !== null
+    ) {
+      setCursorArr((prevArr) => [...prevArr, response.data.nextCursor]);
+    }
+
+    if (page === 0) {
+      setPrevBtnDisabled(true);
+    } else {
+      setPrevBtnDisabled(false);
+    }
+    if (response.data.nextCursor === null) {
+      setNextBtnDisabled(true);
+    } else {
+      setNextBtnDisabled(false);
+    }
   };
 
-  const handlePrevBtn = () => {};
+  const handlePrevBtn = () => {
+    if (donations.length < 4 && page === 0) {
+      setPage((prevValue) => prevValue);
+    } else if (page > 0) {
+      setPage((prevValue) => prevValue - 1);
+    }
+  };
 
   const handleNextBtn = () => {
-    handleLoad(cursor);
+    if (donations.length < 4) {
+      setPage((prevValue) => prevValue);
+    } else {
+      setPage((prevValue) => prevValue + 1);
+    }
   };
 
   useEffect(() => {
-    handleLoad(cursor);
-  }, []);
+    handleLoad(cursorArr[page]);
+  }, [page, prevBtnDisabled, nextBtnDisabled]);
 
   return (
     <>
@@ -63,7 +92,11 @@ export default function SupportSection() {
         <div className={styles.sectionContent}>
           <div className={styles.slideContainer}>
             <div className={styles.sliderBtn}>
-              <Button.Arrow direction="left" onClick={handlePrevBtn} />
+              <Button.Arrow
+                direction="left"
+                onClick={handlePrevBtn}
+                disabled={prevBtnDisabled}
+              />
             </div>
             <ul
               className={styles.supportLists}
@@ -82,7 +115,11 @@ export default function SupportSection() {
               })}
             </ul>
             <div className={styles.sliderBtn}>
-              <Button.Arrow direction="right" onClick={handleNextBtn} />
+              <Button.Arrow
+                direction="right"
+                onClick={handleNextBtn}
+                disabled={nextBtnDisabled}
+              />
             </div>
           </div>
         </div>

--- a/src/pages/List/SupportSection.jsx
+++ b/src/pages/List/SupportSection.jsx
@@ -1,11 +1,12 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import axios from "axios";
 import Card from "components/Card";
 import Button from "components/Button";
-import donationMockData from "mockData/donations.json";
 import styles from "./List.module.scss";
 
 export default function SupportSection() {
-  const [donations, setDonations] = useState(donationMockData);
+  const [donations, setDonations] = useState([]);
+  const [cursor, setCursor] = useState(0);
   const [isDown, setIsDown] = useState(false);
   const [startX, setStartX] = useState(null);
   const [scrollLeft, setScrollLeft] = useState(null);
@@ -31,6 +32,30 @@ export default function SupportSection() {
     slider.current.scrollLeft = scrollLeft - walk;
   };
 
+  const handleLoad = async (nextCursor) => {
+    const instance = axios.create({
+      baseURL: "https://fandom-k-api.vercel.app/6-4",
+      timeout: 10000,
+    });
+
+    const response = await instance.get(
+      `/donations?pageSize=4&cursor=${nextCursor}`,
+    );
+
+    setDonations(response.data.list);
+    setCursor(response.data.nextCursor);
+  };
+
+  const handlePrevBtn = () => {};
+
+  const handleNextBtn = () => {
+    handleLoad(cursor);
+  };
+
+  useEffect(() => {
+    handleLoad(cursor);
+  }, []);
+
   return (
     <>
       <section className={styles.section}>
@@ -38,7 +63,7 @@ export default function SupportSection() {
         <div className={styles.sectionContent}>
           <div className={styles.slideContainer}>
             <div className={styles.sliderBtn}>
-              <Button.Arrow direction="left" />
+              <Button.Arrow direction="left" onClick={handlePrevBtn} />
             </div>
             <ul
               className={styles.supportLists}
@@ -57,7 +82,7 @@ export default function SupportSection() {
               })}
             </ul>
             <div className={styles.sliderBtn}>
-              <Button.Arrow direction="right" />
+              <Button.Arrow direction="right" onClick={handleNextBtn} />
             </div>
           </div>
         </div>

--- a/src/pages/List/SupportSection.jsx
+++ b/src/pages/List/SupportSection.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import useResponsive from "hooks/useResponsive";
+import useRequest from "hooks/useRequest";
 import axios from "axios";
 import Card from "components/Card";
 import Button from "components/Button";
@@ -15,6 +16,23 @@ export default function SupportSection() {
   const [startX, setStartX] = useState(null);
   const [scrollLeft, setScrollLeft] = useState(null);
   const slider = useRef();
+
+  const {
+    data,
+    isLoading,
+    error,
+    requestFunc: getDonationsData,
+  } = useRequest({
+    skip: true,
+    options: {
+      method: "get",
+      url: "/donations",
+      params: {
+        pageSize: isPC ? 4 : null,
+        cursor: cursorArr[page],
+      },
+    },
+  });
 
   const handleMouseDown = (e) => {
     setIsDown(true);
@@ -36,15 +54,8 @@ export default function SupportSection() {
     slider.current.scrollLeft = scrollLeft - walk;
   };
 
-  const handleLoad = async (cursor) => {
-    const instance = axios.create({
-      baseURL: "https://fandom-k-api.vercel.app/6-4",
-      timeout: 10000,
-    });
-
-    const response = await instance.get(
-      `/donations?${isPC ? "pageSize=4" : ""}&cursor=${cursor}`,
-    );
+  const handleLoad = async () => {
+    const response = await getDonationsData();
 
     if (isPC) {
       setNextCursor(response.data.nextCursor);
@@ -78,7 +89,7 @@ export default function SupportSection() {
   };
 
   useEffect(() => {
-    handleLoad(cursorArr[page]);
+    handleLoad();
   }, [page, isPC]);
 
   return (


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
ListPage > SupportSection 데이터 연결, 페이지네이션


# 어떻게 해결했나요?
ListPage > SupportSection 데이터 연결했습니다.
- useResponsive 훅 적용 (react-responsive 사용)
- 페이지네이션 이전버튼, 다음버튼 모두 가능
- 태블릿, 모바일 버전에서 페이지네이션 X, 슬라이드로 동작함 -> lazy loading 추후에 적용할 것

![Screenshot 2024-05-07 at 13 10 39](https://github.com/miraclee1226/Fandom-k/assets/21290609/33e95ee6-96ec-41e0-8392-c60a838d9cee)


### useResponsive hook
~~~~
const [isPC, isTablet, isMobile] = useResponsive();
~~~~
npm install 해주시고
추가하시면 창사이즈에 따라 PC인지, 태블릿인지, 모바일인지 확인하는 불린형 변수를 사용하실 수 있습니다~