### PR TITLE
[소혜린] Feat(WIP): 이미지 최적화

### DIFF
--- a/src/components/ChartItem/ChartItem.jsx
+++ b/src/components/ChartItem/ChartItem.jsx
@@ -6,7 +6,7 @@ export default function ChartItem({ data }) {
     <div className={styles.chartItemContainer}>
       <div className={styles.content}>
         <div className={styles.image}>
-          <Image.Round/>
+          <Image.Round src={data.profilePicture} lazyMode={true} />
         </div>
         <span className={styles.ranking}>{data.rank}</span>
         <strong className={styles.name}>{data.name}</strong>

--- a/src/components/Image/RectangleImage/RectangleImage.jsx
+++ b/src/components/Image/RectangleImage/RectangleImage.jsx
@@ -6,5 +6,15 @@ export default function RectangleImage() {
     <div className={styles.rectangleImage}>
       <img src={IdolImg} alt="채원 이미지" />
     </div>
+
+    // SupportCard img 변경 후 주석 해제
+    // <div className={styles.rectangleImage}>
+    // {lazyMode ? (
+    //   <WebpLoader.Lazy src={src} webpSrc={src} />
+    // ) : (
+    //   <WebpLoader src={src} webpSrc={src} />
+    // )}
+    // </div>
   );
 }
+

--- a/src/components/Image/RoundImage/RoundImage.jsx
+++ b/src/components/Image/RoundImage/RoundImage.jsx
@@ -1,10 +1,21 @@
+import { useState, useEffect } from "react";
 import styles from "components/Image/Image.module.scss";
-import IdolImg from "assets/Image_Idol.png";
+import WebpLoader from "components/WebpLoader";
 
-export default function RoundImage() {
+export default function RoundImage({ src, lazyMode = false }) {
+  let webpSrc = null;
+
+  if (src.endsWith(".webp")) {
+    webpSrc = src;
+  }
+
   return (
     <div className={styles.roundImage}>
-      <img src={IdolImg} alt="르세라핌 채원 이미지" />
+      {lazyMode ? (
+        <WebpLoader.Lazy src={src} webpSrc={webpSrc} />
+      ) : (
+        <WebpLoader src={src} webpSrc={webpSrc} />
+      )}
     </div>
   );
 }

--- a/src/components/WebpLoader/WebpLoader.jsx
+++ b/src/components/WebpLoader/WebpLoader.jsx
@@ -1,0 +1,23 @@
+import useLazyImageObserver from "hooks/useLazyImageObserver";
+
+export default function WebpLoader({ src, webpSrc }) {
+  return (
+    <picture>
+      {webpSrc && <source srcSet={webpSrc} type="image/webp" />}
+      <img src={src} />
+    </picture>
+  );
+}
+
+function LazyModeWebpLoader({ src, webpSrc }) {
+  const { imgRef, imgSrc } = useLazyImageObserver({ src: webpSrc && src });
+  
+  return (
+    <picture>
+      {webpSrc && <source srcSet={imgSrc} type="image/webp" />}
+      <img ref={imgRef} src={imgSrc} />
+    </picture>
+  );
+}
+
+WebpLoader.Lazy = LazyModeWebpLoader;

--- a/src/components/WebpLoader/index.js
+++ b/src/components/WebpLoader/index.js
@@ -1,0 +1,1 @@
+export { default } from './WebpLoader';

--- a/src/hooks/useLazyImageObserver.jsx
+++ b/src/hooks/useLazyImageObserver.jsx
@@ -1,0 +1,31 @@
+import { useEffect, useRef, useState } from "react";
+
+export default function useLazyImageObserver({ src }) {
+  const [imgSrc, setImgSrc] = useState("");
+  const imgRef = useRef(null);
+
+  useEffect(() => {
+    let observer;
+
+    if (imgRef && !imgSrc) {
+      observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              setImgSrc(src);
+              observer.unobserve(imgRef.current);
+            }
+          });
+        },
+        { threshold: 0.25 },
+      );
+      observer.observe(imgRef.current);
+    }
+
+    return () => {
+      observer && observer.disconnect();
+    };
+  }, [imgRef, imgSrc, src]);
+
+  return { imgSrc, imgRef };
+}

--- a/src/mockData/femaleData.json
+++ b/src/mockData/femaleData.json
@@ -3,7 +3,7 @@
     "id": 0,
     "name": "장원영1",
     "group": "아이브1",
-    "profilePicture": "https://example.com/profile.jpg",
+    "profilePicture": "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Fandom-K/idol/1714970111849/minji.webp",
     "totalVotes": 10000,
     "rank": 1
   },
@@ -11,7 +11,7 @@
     "id": 1,
     "name": "장원영2",
     "group": "아이브2",
-    "profilePicture": "https://example.com/profile.jpg",
+    "profilePicture": "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Fandom-K/idol/1714969988794/hani.webp",
     "totalVotes": 9000,
     "rank": 2
   },
@@ -19,7 +19,7 @@
     "id": 2,
     "name": "장원영3",
     "group": "아이브3",
-    "profilePicture": "https://example.com/profile.jpg",
+    "profilePicture": "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Fandom-K/idol/1714981034611/test3.jpg",
     "totalVotes": 8000,
     "rank": 3
   },
@@ -27,7 +27,7 @@
     "id": 3,
     "name": "장원영4",
     "group": "아이브4",
-    "profilePicture": "https://example.com/profile.jpg",
+    "profilePicture": "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Fandom-K/idol/1714970184429/chewon.webp",
     "totalVotes": 7000,
     "rank": 4
   },
@@ -35,7 +35,7 @@
     "id": 4,
     "name": "장원영5",
     "group": "아이브5",
-    "profilePicture": "https://example.com/profile.jpg",
+    "profilePicture": "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Fandom-K/idol/1714964987085/limhyunsik.webp",
     "totalVotes": 6000,
     "rank": 5
   },
@@ -43,7 +43,7 @@
     "id": 5,
     "name": "장원영6",
     "group": "아이브6",
-    "profilePicture": "https://example.com/profile.jpg",
+    "profilePicture": "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Fandom-K/idol/1714973792799/jeonjungkook.webp",
     "totalVotes": 5000,
     "rank": 6
   },
@@ -51,7 +51,7 @@
     "id": 6,
     "name": "장원영7",
     "group": "아이브7",
-    "profilePicture": "https://example.com/profile.jpg",
+    "profilePicture": "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Fandom-K/idol/1714973925420/rm.webp",
     "totalVotes": 4000,
     "rank": 7
   },
@@ -59,7 +59,7 @@
     "id": 7,
     "name": "장원영8",
     "group": "아이브8",
-    "profilePicture": "https://example.com/profile.jpg",
+    "profilePicture": "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Fandom-K/idol/1714970271375/jenny.webp",
     "totalVotes": 3000,
     "rank": 8
   },
@@ -67,7 +67,7 @@
     "id": 8,
     "name": "장원영9",
     "group": "아이브9",
-    "profilePicture": "https://example.com/profile.jpg",
+    "profilePicture": "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Fandom-K/idol/1714970296656/winter.webp",
     "totalVotes": 2000,
     "rank": 9
   },
@@ -75,7 +75,7 @@
     "id": 9,
     "name": "장원영10",
     "group": "아이브10",
-    "profilePicture": "https://example.com/profile.jpg",
+    "profilePicture": "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Fandom-K/idol/1714970207790/karina.webp",
     "totalVotes": 1000,
     "rank": 10
   }

--- a/src/pages/List.jsx
+++ b/src/pages/List.jsx
@@ -32,7 +32,7 @@ function CreditSection() {
         <div className={styles.leftContent}>
           <span>내 크레딧</span>
           <div className={styles.credit}>
-            <img src={CreditIcon} alt="credit" />
+            <img src={creditIcon} alt="credit" />
             <span>{(36000).toLocaleString()}</span>
           </div>
         </div>

--- a/src/pages/MyPage/AddFavoriteSection.jsx
+++ b/src/pages/MyPage/AddFavoriteSection.jsx
@@ -28,7 +28,7 @@ export default function AddFavoriteSection({ idols }) {
                         />
                         <label htmlFor={idol.id} className={styles.labelItem}>
                           <div className={styles.imgWrap}>
-                            <Image.Round />
+                            <Image.Round src={idol.profilePicture} lazyMode={true} />
                           </div>
                         </label>
                         <span className={styles.itemInfo}>

--- a/src/pages/MyPage/AddedFavoriteSection.jsx
+++ b/src/pages/MyPage/AddedFavoriteSection.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import Image from "components/Image";
 import TouchArea from "components/TouchArea";
 import { ReactComponent as DeleteIcon } from "assets/icons/round_x_icon.svg";
-import mockData from "mockData/maleData.json";
+import mockData from "mockData/femaleData.json";
 import styles from "./MyPage.module.scss";
 
 export default function AddedFavoriteSection() {
@@ -26,7 +26,7 @@ export default function AddedFavoriteSection() {
                       </TouchArea>
                     </div>
                     <div className={styles.roundImage}>
-                      <Image.Round />
+                      <Image.Round src={idol.profilePicture} lazyMode={true} />
                     </div>
                     <span className={styles.itemInfo}>
                       <strong className={styles.itemTitle}>{idol.name}</strong>


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
- RoundImage와 RectangleImage 컴포넌트 이미지 최적화입니다.

# 어떻게 해결했나요?
- useLazyImageObserver 커스텀 훅을 사용해서 스크롤 시 새로운 이미지가 불러지도록 했습니다.

![이미지 최적화](https://github.com/miraclee1226/Fandom-k/assets/96684473/3cbf9986-a99a-458f-b51d-7438e38993d6)
위 사진의 네모박스안을 보시면 lazy image가 적용된 경우, 스크롤 이동에 따라 이미지가 viewport에 노출되는 순간 순차적으로 로드되는 것을 알 수 있습니다.

# 참고
- webp 파일 이외의 파일은 이미지가 불러와지지 않는 오류가 있습니다. 따라서 멘토링 시간에 질문드릴 예정입니다.