### PR TITLE
[천권희] useAsync hook 생성

### DIFF
--- a/src/hooks/useAsync.js
+++ b/src/hooks/useAsync.js
@@ -1,0 +1,33 @@
+import { useCallback, useState } from "react";
+
+/**
+ * 비동기 함수를 감싼 함수를 반환하는 Hook입니다.
+ * pending과 error 상태를 관리합니다.
+ *
+ * @param {Function} asyncFunc - 비동기 함수
+ * @returns {Object} - { wrappedFunc, pending, error }
+ */
+export default function useAsync(asyncFunc) {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState(null);
+
+  const wrappedFunc = useCallback(
+    async (...args) => {
+      setPending(true);
+      setError(null);
+
+      try {
+        return await asyncFunc(...args);
+      } catch (err) {
+        setError(err);
+      } finally {
+        setPending(false);
+      }
+
+      return null;
+    },
+    [asyncFunc],
+  );
+
+  return { wrappedFunc, pending, error };
+}


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?

이전 useRequest hook을 직접 사용해보니 requestFunc에 인수를 넣는 어려움이 있었습니다.

# 어떻게 해결했나요?

비동기 함수를 감싼 함수를 반환하는 useAsync hook을 생성하였습니다.

# 사용 방법

0. `npm install` 후 프로젝트 디렉토리 최상단에 .env 파일을 아래와 같이 만들어주세요.
```
REACT_APP_BASE_URL="https://fandom-k-api.vercel.app/6-4"
```

1. Swagger API 문서에 맞게 요청 함수를 작성합니다.
```js
// getIdolsData.js
import dispatcher from "./dispatcher";

const getIdolsData = async ({ pageSize = 10 }) => {
  const result = await dispatcher({
    method: "get",
    url: "/idols",
    params: {
      pageSize,
    },
  });

  return result;
};

export default getIdolsData;
```

2. 데이터를 불러오고자 하는 컴포넌트에서 useRequest hook을 사용합니다.
```js
export default function List() {
  const [data, setData] = useState(null);
  const {
    wrappedFunc: getIdolsDataAsync,
    pending: loading,
    error,
  } = useAsync(getIdolsData);

  useEffect(() => {
    (async () => {
      const result = await getIdolsDataAsync({ pageSize: 16 });

      setData(result);
    })();
  }, []);

  if (loading) return <div>loading...</div>;
  if (error) return <div>errror</div>;

  return (
    <>
      <Navbar />
      <Layout>
        <CreditSection />
        <SupportSection />
        <ChartSection />
      </Layout>
    </>
  );
}
```


_이전의 useRequest hook을 혹시 사용하고 계신 분이 있을 수 있어 파일을 삭제하지는 않았습니다.
후에 제가 확인하고 삭제하도록 하겠습니다._



