### PR TITLE
[소혜린] Feat: 크레딧 localStorage에 저장기능 개발

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.6.8",
         "classnames": "^2.5.1",
+        "jotai": "^2.8.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-modal": "^3.16.1",
@@ -5514,14 +5515,7 @@
       "version": "1.6.8",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
       "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
-<<<<<<< HEAD
-<<<<<<< HEAD
       "dev": true,
-=======
->>>>>>> f562859ddcdc1363569ab3cfdc397b5653bf08c9
-=======
-      "dev": true,
->>>>>>> e596f22e2aeaa5e28ae005f9b0b999276493abeb
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -5532,14 +5526,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-<<<<<<< HEAD
-<<<<<<< HEAD
       "dev": true,
-=======
->>>>>>> f562859ddcdc1363569ab3cfdc397b5653bf08c9
-=======
-      "dev": true,
->>>>>>> e596f22e2aeaa5e28ae005f9b0b999276493abeb
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -13171,6 +13158,26 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jotai": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.8.0.tgz",
+      "integrity": "sha512-yZNMC36FdLOksOr8qga0yLf14miCJlEThlp5DeFJNnqzm2+ZG7wLcJzoOyij5K6U6Xlc5ljQqPDlJRgqW0Y18g==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -16446,17 +16453,8 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-<<<<<<< HEAD
-<<<<<<< HEAD
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
-=======
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
->>>>>>> f562859ddcdc1363569ab3cfdc397b5653bf08c9
-=======
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
->>>>>>> e596f22e2aeaa5e28ae005f9b0b999276493abeb
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.6.8",
     "classnames": "^2.5.1",
+    "jotai": "^2.8.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-modal": "^3.16.1",

--- a/src/components/Modal/CreditChargeModal/CreditChargeModal.jsx
+++ b/src/components/Modal/CreditChargeModal/CreditChargeModal.jsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
+import { useAtom } from "jotai";
 import classNames from "classnames/bind";
 import Button from "components/Button";
 import { ReactComponent as CreditIcon } from "assets/icons/credit.svg";
 import { ReactComponent as XIcon } from "assets/icons/x_icon.svg";
+import creditAtomWithPersistence from "context/jotai";
 import DefaultModal from "../Modal";
 import styles from "../Modal.module.scss";
 
@@ -12,13 +14,16 @@ const CHARGE_AMOUNTS = [100, 500, 1000];
 
 export default function CreditChargeModal({ isOpen, handleModalOpen }) {
   const [checkedValue, setCheckedValue] = useState("");
+  const [credit, setCredit] = useAtom(creditAtomWithPersistence);
 
   const handleRadioChange = (e) => {
     setCheckedValue(e.target.value);
   };
 
   const handleChargeCredit = () => {
-    // TODO: Credit 충전 핸들러
+    const updatedCredit = Number(credit) + Number(checkedValue);
+
+    setCredit(updatedCredit);
     handleModalOpen(false);
   };
 

--- a/src/components/Modal/VoteModal/VoteModal.jsx
+++ b/src/components/Modal/VoteModal/VoteModal.jsx
@@ -1,32 +1,29 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useAtom } from "jotai";
 import classNames from "classnames/bind";
 import Button from "components/Button";
 import Image from "components/Image";
 import { addCommas } from "utils/commas";
 import { ReactComponent as XIcon } from "assets/icons/x_icon.svg";
-import femaleData from "mockData/femaleData";
 import useRequest from "hooks/useRequest";
+import Modal from "components/Modal";
+import creditAtomWithPersistence from "context/jotai";
 import DefaultModal from "../Modal";
 import styles from "../Modal.module.scss";
 
-const SUBTRACT_CREDIT = 1000;
 const cn = classNames.bind(styles);
+
+const SUBTRACT_CREDIT = 1000;
 
 export default function VoteModal({ data, isOpen, handleModalOpen, gender }) {
   const [checkedValue, setCheckedValue] = useState("");
-  const [credit, setCredit] = useState(0);
-
-  const getCredit = () => {
-    const storedCredit = localStorage.getItem('Credit');
-
-    return storedCredit;
-  }
-
+  const [credit, setCredit] = useAtom(creditAtomWithPersistence);
+  
   const handleVote = async () => {
-    setCredit((prev) => prev - SUBTRACT_CREDIT);
-    
-    localStorage.setItem('Credit', credit - SUBTRACT_CREDIT);
-    
+    const updatedCredit = Number(credit) - SUBTRACT_CREDIT;
+
+    setCredit(updatedCredit);
+
     handleModalOpen(false);
     await voteIdols();
   };
@@ -45,10 +42,6 @@ export default function VoteModal({ data, isOpen, handleModalOpen, gender }) {
       },
     }
   })
-
-  useEffect(() => {
-    setCredit(getCredit());
-  }, []);
 
   return (
     <DefaultModal isOpen={isOpen} handleModalOpen={handleModalOpen}>

--- a/src/context/jotai.js
+++ b/src/context/jotai.js
@@ -1,0 +1,13 @@
+import { atom } from 'jotai';
+
+const storedCreditAtom = atom(localStorage.getItem('Credit') || 0);
+
+const creditAtomWithPersistence = atom(
+  (get) => get(storedCreditAtom),
+  (get, set, newCredit) => {
+    set(storedCreditAtom, newCredit);
+    localStorage.setItem('Credit', newCredit);
+  }
+)
+
+export default creditAtomWithPersistence;

--- a/src/pages/List/ChartSection.jsx
+++ b/src/pages/List/ChartSection.jsx
@@ -1,10 +1,12 @@
 import { useState, useEffect } from "react";
+import { useAtom } from "jotai";
 import Tab from "components/Tab";
 import ChartItem from "components/ChartItem";
 import Button from "components/Button";
 import { ReactComponent as ChartIcon } from "assets/icons/chart.svg";
 import Modal from "components/Modal";
 import useRequest from "hooks/useRequest";
+import creditAtomWithPersistence from "context/jotai";
 import styles from "./List.module.scss";
 
 export default function ChartSection() {
@@ -12,6 +14,8 @@ export default function ChartSection() {
   const [pageSize, setPageSize] = useState(10);
   const [data, setData] = useState([]);
   const [isOpen, setIsOpen] = useState(false);
+  const [isOpenWarningModal, setIsOpenWarningModal] = useState(false);
+  const [credit, setCredit] = useAtom(creditAtomWithPersistence);
   const { requestFunc: getChartData } = useRequest({
     skip: true,
     options: {
@@ -23,16 +27,20 @@ export default function ChartSection() {
       },
     },
   });
-  
+
   const handleTabChange = (index) => {
     setGender(index === 0 ? "female" : "male");
   };
 
   const handleButtonClick = () => setPageSize((prev) => prev + 10);
 
-  const handleModalOpen = async () => {
-    setIsOpen(!isOpen);
-    await getChartData();
+  const handleModalOpen = async (isModalOpen) => {
+    if (Number(credit) > 999) {
+      setIsOpen(isModalOpen);
+      await getChartData();
+    } else {
+      setIsOpenWarningModal(isModalOpen);
+    }
   };
 
   useEffect(() => {
@@ -52,7 +60,8 @@ export default function ChartSection() {
             <ChartIcon />
             차트 투표하기
           </Button.Round>
-          <Modal.Vote data={data} isOpen={isOpen} handleModalOpen={handleModalOpen} gender={gender} />
+          <Modal.Vote data={data} isOpen={!!isOpen} handleModalOpen={handleModalOpen} gender={gender} />
+          <Modal.CreditWarning isOpen={!!isOpenWarningModal} handleModalOpen={handleModalOpen} />
         </div>
         <div className={styles.sectionDetail}>
           <div className={styles.tab}>

--- a/src/pages/List/CreditSection.jsx
+++ b/src/pages/List/CreditSection.jsx
@@ -1,10 +1,17 @@
+import { useState } from "react";
+import { useAtom } from "jotai";
 import Button from "components/Button";
 import { ReactComponent as CreditIcon } from "assets/icons/credit.svg";
+import Modal from "components/Modal";
+import creditAtomWithPersistence from "context/jotai";
 import styles from "./List.module.scss";
 
 export default function CreditSection() {
-  const handleChargeCredit = () => {
-    // TODO: 충전 Modal을 pop up 합니다.
+  const [isOpen, setIsOpen] = useState(false);
+  const [credit, setCredit] = useAtom(creditAtomWithPersistence);
+  
+  const handleModalOpen = () => {
+    setIsOpen(!isOpen)
   };
 
   return (
@@ -14,15 +21,16 @@ export default function CreditSection() {
           <span>내 크레딧</span>
           <div className={styles.credit}>
             <CreditIcon width={24} height={24} />
-            <span>{(36000).toLocaleString()}</span>
+            <span>{credit.toLocaleString()}</span>
           </div>
         </div>
         <Button.Text
           className={styles.rightContent}
-          onClick={handleChargeCredit}
+          onClick={handleModalOpen}
         >
           충전하기
         </Button.Text>
+        <Modal.CreditCharge isOpen={isOpen} handleModalOpen={handleModalOpen} />
       </div>
     </section>
   );


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
- 크레딧 충전 시 선택한 크레딧 localStorage에 저장
- 투표하기 버튼 클릭 시 크레딧 1000감소
- 크레딧이 1000 미만인 경우 CreditWarningModal 띄우기

# 어떻게 해결했나요?
- Jotai를 이용해 localStorage 값을 저장하여 전역 상태 관리를 했습니다.
    - 참고했던 글 첨부하겠습니다: https://jotai.org/docs/guides/persistence
    
# 사용방법
투표하면 크레딧이 1000 감소하는 Vote Modal을 예시로 들겠습니다. 
useAtom, creditAtomWithPersistence 를 import 해주시고, setCredit의 state안에 변경하고 싶은 값을 넣어주시면 됩니다!

Jotai가 처음이라 맞게 했는지 모르겠습니다ㅎㅎ 매운맛 리뷰 부탁드려요🔥

```
// Vote Modal.jsx
import { useAtom } from "jotai";
import creditAtomWithPersistence from "context/jotai";

const [credit, setCredit] = useAtom(creditAtomWithPersistence);

const handleVote = async () => {
    const updatedCredit = credit - 1000;
    setCredit(updatedCredit);
 };
```