### PR TITLE
[소혜린] useLazyImageObserver.js 예외 처리

### DIFF
--- a/src/hooks/useLazyImageObserver.js
+++ b/src/hooks/useLazyImageObserver.js
@@ -13,7 +13,7 @@ export default function useLazyImageObserver({ src }) {
           entries.forEach((entry) => {
             if (entry.isIntersecting) {
               setImgSrc(src);
-              observer.unobserve(imgRef.current);
+              if (imgRef.current) observer.unobserve(imgRef.current);
             }
           });
         },


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
- Uncaught TypeError: Failed to execute 'unobserve' on 'IntersectionObserver': parameter 1 is not of type 'Element'. 에러 해결 입니다.

# 어떻게 해결했나요?
- if (imgRef.current) 를 추가하여 예외처리 해주었습니다.