### PR TITLE
[이율] Fix: SupportSection 가로 1200px에서 버튼 가려지는 문제

### DIFF
--- a/src/pages/List/List.module.scss
+++ b/src/pages/List/List.module.scss
@@ -68,18 +68,36 @@
 
   .sliderBtn {
     display: none;
-    @media screen and (min-width: calc($desktop + 78px * 2 + 80px)) {
+    @media screen and (min-width: $desktop) {
       display: block;
       position: absolute;
       top: 50%;
+      z-index: 2;
     }
+
     &:first-child {
       left: -40px;
       transform: translate(-100%, -50%);
+      @media screen and (max-width: calc($desktop + 78px * 2 + 80px)) {
+        left: 0;
+        transform: translate(0, -50%);
+        opacity: 0.7;
+        &:hover {
+          opacity: 1;
+        }
+      }
     }
     &:last-child {
       right: -40px;
       transform: translate(100%, -50%);
+      @media screen and (max-width: calc($desktop + 78px * 2 + 80px)) {
+        right: 0;
+        transform: translate(0, -50%);
+        opacity: 0.7;
+        &:hover {
+          opacity: 1;
+        }
+      }
     }
   }
   .error {


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
1200px 즈음에서 슬라이드 버튼이 가려지는 문제

# 어떻게 해결했나요?
위치, opacity 적용했습니다

![image](https://github.com/miraclee1226/Fandom-k/assets/21290609/4cf289f8-9293-4cde-b546-b85e48df73f0)
