### PR TITLE
Fix: fix default credit

### DIFF
--- a/src/context/Credit.js
+++ b/src/context/Credit.js
@@ -1,6 +1,6 @@
 import { atom } from "jotai";
 
-const storedCreditAtom = atom(localStorage.getItem("Credit") || 0);
+const storedCreditAtom = atom(localStorage.getItem("Credit") || 100000);
 
 const creditAtomWithPersistence = atom(
   (get) => get(storedCreditAtom),


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
기본 credit 0 --> 100000 으로 변경

# 어떻게 해결했나요?
const storedCreditAtom = atom(localStorage.getItem("Credit") || 100000);
기본 credit 값을 100000으로 변경